### PR TITLE
Feature: Add time-series query for user sleeps API

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+# Request for Change (RFC)
+
+The background of what this PR does and why it's needed, @mentions of the person or team responsible for reviewing proposed changes, and reference related issues to this PR, as follows:
+
+- Closes #ISSUE_NUMBER
+- Fixes #ISSUE_NUMBER
+- Resolves #ISSUE_NUMBER
+
+## Changes
+
+List the key changes and a brief description of those proposed:
+
+- **New features:**
+- **Bug fixes:**
+- **Improvements:**
+
+## Dependencies
+
+Any new dependencies, config changes, or infrastructure updates?
+
+## Testing Instructions
+
+Detail the steps necessary to test these changes.
+
+## Notes
+
+Breaking changes, migration steps, or other important info for reviewers.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::API
   include ResponseHandler
   include ExceptionHandler
   include PaginationHandler
+  include DateRangeHandler
 
   def catch404
     raise ActionController::RoutingError, "Resource not found: #{request.path}"

--- a/app/controllers/concerns/date_range_handler.rb
+++ b/app/controllers/concerns/date_range_handler.rb
@@ -1,0 +1,42 @@
+module DateRangeHandler
+  extend ActiveSupport::Concern
+
+  MAX_INTERVAL_SECONDS = ENV.fetch("DEFAULT_SCOPE_LIMIT", 25).to_i.days.to_i
+
+  def date_range_params!
+    permitted_params = params.permit(:start, :end)
+    parse_date_range!(permitted_params)
+  end
+
+  private
+
+  def parse_date_range!(params)
+    start_time = nil
+    end_time = nil
+
+    # Handle the case where both parameters are present
+    if params[:start].present? && params[:end].present?
+      start_time = Time.at(params[:start].to_i)
+      end_time = Time.at(params[:end].to_i)
+
+      # Validate date order
+      raise ActionController::ParameterMissing, "Start date must be before or equal to the end date" if start_time > end_time
+
+      # Validate maximum duration
+      raise ActionController::ParameterMissing, "The time range cannot exceed #{MAX_INTERVAL_SECONDS / 1.day} days" if (end_time - start_time) > MAX_INTERVAL_SECONDS
+
+    # Handle the case where only one parameter is present
+    elsif params[:start].present?
+      start_time = Time.at(params[:start].to_i)
+      end_time = start_time + MAX_INTERVAL_SECONDS
+
+    elsif params[:end].present?
+      end_time = Time.at(params[:end].to_i)
+      start_time = end_time - MAX_INTERVAL_SECONDS
+    end
+
+    [ start_time, end_time ]
+  rescue ArgumentError, TypeError => e
+    raise ActionController::ParameterMissing, "Invalid date format: #{e.message}"
+  end
+end

--- a/app/controllers/concerns/pagination_handler.rb
+++ b/app/controllers/concerns/pagination_handler.rb
@@ -10,11 +10,11 @@ module PaginationHandler
 
   def render_pagy_response(data: {}, message: "", status: :ok, meta: {})
     render_success_response(data:, message:, status:, meta: {
-                              current_page: meta[:page],
-                              next_page: meta[:next],
-                              prev_page: meta[:prev],
-                              total_pages: meta[:pages],
-                              total_count: meta[:count]
-                            }.compact)
+                                                              current_page: meta[:page],
+                                                              next_page: meta[:next],
+                                                              prev_page: meta[:prev],
+                                                              total_pages: meta[:pages],
+                                                              total_count: meta[:count]
+                                                            }.compact)
   end
 end

--- a/app/controllers/v1/user/sleeps_controller.rb
+++ b/app/controllers/v1/user/sleeps_controller.rb
@@ -6,7 +6,12 @@ class V1::User::SleepsController < ApplicationController
 
   # GET /users/1/sleeps
   def index
-    @pagy, @user_sleeps = pagy(@user.sleeps.ordered, **pagination_params)
+    start_time, end_time = date_range_params!
+
+    sleeps = @user.sleeps
+    sleeps = sleeps.between(start_time:, end_time:) if start_time.present? && end_time.present?
+
+    @pagy, @user_sleeps = pagy(sleeps.ordered, **pagination_params)
 
     render_pagy_response(
       data: @user_sleeps,

--- a/app/models/user/sleep.rb
+++ b/app/models/user/sleep.rb
@@ -6,11 +6,8 @@ class User::Sleep < ApplicationRecord
 
   scope :ordered, -> { order(start_time: :desc) }
   scope :ranked, -> { where.not(end_time: nil).order(duration: :desc, id: :asc) }
-
-  # TODO: Provide user sleeps filtering based on date range,
-  # rather than simply displaying the last 2 weeks of data.
-  # Example URL:  '/api/v1/users/1/sleeps?start=1755801646&end=1758480046'
   scope :recent, -> { where(start_time: 1.week.ago.beginning_of_week..) }
+  scope :between, ->(start_time:, end_time:) { where(start_time: start_time..end_time) }
 
   before_save :set_duration
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,4 +1,5 @@
 
+Pagy::DEFAULT[:limit] = ENV.fetch("DEFAULT_SCOPE_LIMIT", 25).to_i
 Pagy::DEFAULT[:count_args] = :id
 
 require "pagy/extras/limit"

--- a/db/migrate/20250924232720_add_split_composite_partial_index_to_user_sleeps.rb
+++ b/db/migrate/20250924232720_add_split_composite_partial_index_to_user_sleeps.rb
@@ -1,0 +1,8 @@
+class AddSplitCompositePartialIndexToUserSleeps < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :user_sleeps, [ :user_id, :start_time ], where: "end_time IS NOT NULL", algorithm: :concurrently
+    add_index :user_sleeps, [ :user_id, :duration ], order: { duration: :desc }, where: "end_time IS NOT NULL", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_24_214833) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_24_232720) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -31,7 +31,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_24_214833) do
     t.integer "duration"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id", "duration"], name: "index_user_sleeps_on_user_id_and_duration", order: { duration: :desc }, where: "(end_time IS NOT NULL)"
     t.index ["user_id", "start_time", "duration"], name: "index_part_user_sleeps_on_user_id_and_start_time_and_duration", where: "(end_time IS NOT NULL)", include: ["end_time"]
+    t.index ["user_id", "start_time"], name: "index_user_sleeps_on_user_id_and_start_time", where: "(end_time IS NOT NULL)"
     t.index ["user_id"], name: "index_user_sleeps_on_user_id"
   end
 

--- a/doc/Sleepbook_demo.postman_collection.json
+++ b/doc/Sleepbook_demo.postman_collection.json
@@ -28,7 +28,7 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{host}}/api/v1/users/:user_id/sleeps",
+											"raw": "{{host}}/api/v1/users/:user_id/sleeps?limit=37&start={{$timestamp}}&end={{$timestamp}}",
 											"host": [
 												"{{host}}"
 											],
@@ -47,8 +47,15 @@
 												},
 												{
 													"key": "limit",
-													"value": "25",
-													"disabled": true
+													"value": "37"
+												},
+												{
+													"key": "start",
+													"value": "{{$timestamp}}"
+												},
+												{
+													"key": "end",
+													"value": "{{$timestamp}}"
 												}
 											],
 											"variable": [


### PR DESCRIPTION
# Request for Change (RFC)

This PR introduces time-series querying functionality to the user sleeps API. Previously, the endpoint only supported pagination on the full dataset, which was inefficient for fetching specific time ranges. This change allows users to filter sleep data by a `start` and `end` timestamp, improving performance and user experience for data analysis.

## Changes

### New features:

- Implemented a time-series query for the `/api/v1/users/:user_id/sleeps` endpoint using start and end Unix timestamp parameters.
- Added robust validation in a concern (DateRangeHandler) to ensure the provided date range is valid. This includes a check that the **start date is before the end date** and that the **total range does not exceed a 25-day limit**.
- The API now provides a flexible default behavior: if only a start or end timestamp is provided, the query automatically sets the other boundary to create a **25-day interval**.

### Improvements:

- **Refactored parameter handling**: The logic for parsing and validating start and end parameters has been extracted into a new, reusable concern, DateRangeHandler, which promotes the **Don't Repeat Yourself (DRY)** principle.
- **Improved error handling**: The concern now raises a specific `ActionController::ParameterMissing` exception for invalid date ranges, ensuring a consistent and predictable `400 Bad Request` response handled by our existing `ExceptionHandler` module.
- **Enhanced model scopes**: A new model scope, `between`, was added to the `User::Sleep` model. This keeps the controller lean and moves the query logic to the model, aligning with the **Fat Model**, **Skinny Controller** pattern.
- **Proper strong parameters**: The controller's private methods now correctly use `params.permit` to explicitly allow `start`, and `end` parameters, eliminating "Unpermitted parameter" warnings in the logs.
- **Optimized database performance**: Added two **partial composite indexes** to the `user_sleeps` table to significantly speed up queries for ordered and ranked sleep data. These indexes `([user_id, start_time]`) and `[user_id, duration]`) are applied only to completed sleep sessions (`end_time IS NOT NULL`), reducing their size and making them more efficient for common queries.

### Testing Instructions

1. Start the Rails server.
2. Have a user with some sleep records in the database.
3. Simulate the following API requests using a tool like `curl` or Postman:

    - **Case 1**: Valid query with both `start` and `end`
       ```bash
       curl 'http://localhost:3000/api/v1/users/1/sleeps?start=1758759143&end=1758845543'
       ```
       Expected result: A paginated list of sleep records for user 1 within the specified date range. 

    - **Case 2**: Valid query with only `start`
       ```bash
       curl 'http://localhost:3000/api/v1/users/1/sleeps?start=1758759143'
       ```
       Expected result: A paginated list of sleep records from the given start date extending 25 days forward.

    - **Case 3**: Valid query with only `end`
       ```bash
       curl 'http://localhost:3000/api/v1/users/1/sleeps?end=1758759143'
       ```
       Expected result: A paginated list of sleep records for the 25-day period ending at the specified timestamp.

    - **Case 4:** Invalid query where `start` is after `end`
       ```bash
       curl 'http://localhost:3000/api/v1/users/1/sleeps?start=1758845543&end=1758759143'
       ```
       Expected response: `400 Bad Request` with the error message "_Start date must be before or equal to the end date_".

    - **Case 5**: Invalid query where range exceeds 25 days
       ```bash
       curl 'http://localhost:3000/api/v1/users/1/sleeps?start=1755801646&end=1758480046'
       ```
       Expected response: `400 Bad Request` with the error message "_The time range cannot exceed 25 days_".